### PR TITLE
builder/aggregation: Supplement the remaining arithmetic operators

### DIFF
--- a/builder/aggregation/arithmetic_builder.go
+++ b/builder/aggregation/arithmetic_builder.go
@@ -86,3 +86,16 @@ func (b *arithmeticBuilder) ModWithoutKey(expressions ...any) *Builder {
 	b.parent.d = append(b.parent.d, bson.E{Key: ModOp, Value: expressions})
 	return b.parent
 }
+
+func (b *arithmeticBuilder) Abs(key string, expression any) *Builder {
+	e := bson.E{Key: Abs, Value: expression}
+	if !b.parent.tryMergeValue(key, e) {
+		b.parent.d = append(b.parent.d, bson.E{Key: key, Value: bson.D{e}})
+	}
+	return b.parent
+}
+
+func (b *arithmeticBuilder) AbsWithoutKey(expression any) *Builder {
+	b.parent.d = append(b.parent.d, bson.E{Key: Abs, Value: expression})
+	return b.parent
+}

--- a/builder/aggregation/arithmetic_builder_test.go
+++ b/builder/aggregation/arithmetic_builder_test.go
@@ -184,3 +184,54 @@ func Test_arithmeticBuilder_ModWithoutKey(t *testing.T) {
 		})
 	}
 }
+
+func Test_arithmeticBuilder_Abs(t *testing.T) {
+	testCases := []struct {
+		name       string
+		key        string
+		expression any
+		expected   bson.D
+	}{
+		{
+			name:       "normal",
+			key:        "hours",
+			expression: "$hours",
+			expected:   bson.D{bson.E{Key: "hours", Value: bson.D{bson.E{Key: "$abs", Value: "$hours"}}}},
+		},
+		{
+			name:       "nested expression",
+			key:        "tempDiff",
+			expression: bson.M{"$subtract": []any{"$startTemp", "$endTemp"}},
+			expected:   bson.D{bson.E{Key: "tempDiff", Value: bson.D{bson.E{Key: "$abs", Value: bson.M{"$subtract": []any{"$startTemp", "$endTemp"}}}}}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, NewBuilder().Abs(tc.key, tc.expression).Build())
+		})
+	}
+}
+
+func Test_arithmeticBuilder_AbsWithoutKey(t *testing.T) {
+	testCases := []struct {
+		name       string
+		expression any
+		expected   bson.D
+	}{
+		{
+			name:       "normal",
+			expression: "$hours",
+			expected:   bson.D{bson.E{Key: "$abs", Value: "$hours"}},
+		},
+		{
+			name:       "nested expression",
+			expression: bson.M{"$subtract": []any{"$startTemp", "$endTemp"}},
+			expected:   bson.D{bson.E{Key: "$abs", Value: bson.M{"$subtract": []any{"$startTemp", "$endTemp"}}}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, NewBuilder().AbsWithoutKey(tc.expression).Build())
+		})
+	}
+}

--- a/builder/aggregation/types.go
+++ b/builder/aggregation/types.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	Abs                   = "$abs"
 	StageLookUpOp         = "$lookup"
 	AddFieldsOp           = "$addFields"
 	SetOp                 = "$set"


### PR DESCRIPTION
feat(builder/aggregation):
- Supplement the remaining arithmetic operators.
- Adjust the order of operator constants.

Related to #29