### PR TITLE
Feat: Refactor model hook and integrate ModelHook across operations.

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -334,7 +334,7 @@ func TestPluginInit_EnableModelHook(t *testing.T) {
 	testCases := []struct {
 		name     string
 		ctx      context.Context
-		ocOption func(tm *testModelHookStruct) operation.OpContextOption
+		ocOption func(tm *testModelHookStruct) []operation.OpContextOption
 		opType   operation.OpType
 
 		wantErr error
@@ -343,52 +343,132 @@ func TestPluginInit_EnableModelHook(t *testing.T) {
 		{
 			name: "beforeInsert",
 			ctx:  context.Background(),
-			ocOption: func(tm *testModelHookStruct) operation.OpContextOption {
-				return operation.WithDoc(tm)
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				return []operation.OpContextOption{
+					operation.WithDoc(tm),
+				}
 			},
 			opType:  operation.OpTypeBeforeInsert,
 			wantErr: nil,
 			want:    1,
 		},
 		{
+			name: "beforeInsert with model hook",
+			ctx:  context.Background(),
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				*tm = 1
+				return []operation.OpContextOption{
+					operation.WithDoc(new(testModelHookStruct)),
+					operation.WithModelHook(tm),
+				}
+			},
+			opType:  operation.OpTypeBeforeInsert,
+			wantErr: nil,
+			want:    2,
+		},
+		{
 			name: "afterInsert",
 			ctx:  context.Background(),
-			ocOption: func(tm *testModelHookStruct) operation.OpContextOption {
-				return operation.WithDoc(tm)
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				return []operation.OpContextOption{
+					operation.WithDoc(tm),
+				}
 			},
 			opType:  operation.OpTypeAfterInsert,
 			wantErr: nil,
 			want:    1,
 		},
 		{
+			name: "afterInsert with model hook",
+			ctx:  context.Background(),
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				*tm = 1
+				return []operation.OpContextOption{
+					operation.WithDoc(new(testModelHookStruct)),
+					operation.WithModelHook(tm),
+				}
+			},
+			opType:  operation.OpTypeAfterInsert,
+			wantErr: nil,
+			want:    2,
+		},
+		{
 			name: "beforeUpsert",
 			ctx:  context.Background(),
-			ocOption: func(tm *testModelHookStruct) operation.OpContextOption {
-				return operation.WithReplacement(tm)
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				return []operation.OpContextOption{
+					operation.WithUpdates(tm),
+				}
 			},
 			opType:  operation.OpTypeBeforeUpsert,
 			wantErr: nil,
 			want:    1,
 		},
 		{
+			name: "beforeUpsert with model hook",
+			ctx:  context.Background(),
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				*tm = 1
+				return []operation.OpContextOption{
+					operation.WithUpdates(new(testModelHookStruct)),
+					operation.WithModelHook(tm),
+				}
+			},
+			opType:  operation.OpTypeBeforeUpsert,
+			wantErr: nil,
+			want:    2,
+		},
+		{
 			name: "afterUpsert",
 			ctx:  context.Background(),
-			ocOption: func(tm *testModelHookStruct) operation.OpContextOption {
-				return operation.WithReplacement(tm)
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				return []operation.OpContextOption{
+					operation.WithUpdates(tm),
+				}
 			},
 			opType:  operation.OpTypeAfterUpsert,
 			wantErr: nil,
 			want:    1,
 		},
 		{
+			name: "afterUpsert with model hook",
+			ctx:  context.Background(),
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				*tm = 1
+				return []operation.OpContextOption{
+					operation.WithUpdates(new(testModelHookStruct)),
+					operation.WithModelHook(tm),
+				}
+			},
+			opType:  operation.OpTypeAfterUpsert,
+			wantErr: nil,
+			want:    2,
+		},
+		{
 			name: "afterFind",
 			ctx:  context.Background(),
-			ocOption: func(tm *testModelHookStruct) operation.OpContextOption {
-				return operation.WithDoc(tm)
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				return []operation.OpContextOption{
+					operation.WithDoc(tm),
+				}
 			},
 			opType:  operation.OpTypeAfterFind,
 			wantErr: nil,
 			want:    1,
+		},
+		{
+			name: "afterFind with model hook",
+			ctx:  context.Background(),
+			ocOption: func(tm *testModelHookStruct) []operation.OpContextOption {
+				*tm = 1
+				return []operation.OpContextOption{
+					operation.WithDoc(new(testModelHookStruct)),
+					operation.WithModelHook(tm),
+				}
+			},
+			opType:  operation.OpTypeAfterFind,
+			wantErr: nil,
+			want:    2,
 		},
 	}
 
@@ -397,7 +477,7 @@ func TestPluginInit_EnableModelHook(t *testing.T) {
 			tm := new(testModelHookStruct)
 			err := callback.GetCallback().Execute(
 				tc.ctx,
-				operation.NewOpContext(nil, tc.ocOption(tm)),
+				operation.NewOpContext(nil, tc.ocOption(tm)...),
 				tc.opType,
 			)
 			require.Nil(t, err)
@@ -407,7 +487,7 @@ func TestPluginInit_EnableModelHook(t *testing.T) {
 			InitPlugin(cfg)
 			err = callback.GetCallback().Execute(
 				tc.ctx,
-				operation.NewOpContext(nil, tc.ocOption(tm)),
+				operation.NewOpContext(nil, tc.ocOption(tm)...),
 				tc.opType,
 			)
 			require.Equal(t, tc.wantErr, err)

--- a/creator/opt_op_context_gen.go
+++ b/creator/opt_op_context_gen.go
@@ -37,3 +37,9 @@ func WithMongoOptions[T any](mongoOptions any) OpContextOption[T] {
 		opContext.MongoOptions = mongoOptions
 	}
 }
+
+func WithModelHook[T any](modelHook any) OpContextOption[T] {
+	return func(opContext *OpContext[T]) {
+		opContext.ModelHook = modelHook
+	}
+}

--- a/creator/types.go
+++ b/creator/types.go
@@ -26,6 +26,7 @@ type OpContext[T any] struct {
 	Doc          *T
 	Docs         []*T
 	MongoOptions any
+	ModelHook    any
 }
 
 type (

--- a/deleter/deleter.go
+++ b/deleter/deleter.go
@@ -37,6 +37,7 @@ func NewDeleter[T any](collection *mongo.Collection) *Deleter[T] {
 type Deleter[T any] struct {
 	collection  *mongo.Collection
 	filter      any
+	modelHook   any
 	beforeHooks []beforeHookFn
 	afterHooks  []afterHookFn
 }
@@ -85,9 +86,14 @@ func (d *Deleter[T]) Filter(filter any) *Deleter[T] {
 	return d
 }
 
+func (d *Deleter[T]) ModelHook(modelHook any) *Deleter[T] {
+	d.modelHook = modelHook
+	return d
+}
+
 func (d *Deleter[T]) DeleteOne(ctx context.Context, opts ...*options.DeleteOptions) (*mongo.DeleteResult, error) {
-	globalPoContext := operation.NewOpContext(d.collection, operation.WithFilter(d.filter), operation.WithMongoOptions(opts))
-	err := d.preActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts)), operation.OpTypeBeforeDelete)
+	globalPoContext := operation.NewOpContext(d.collection, operation.WithFilter(d.filter), operation.WithMongoOptions(opts), operation.WithModelHook(d.modelHook))
+	err := d.preActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts), WithModelHook(d.modelHook)), operation.OpTypeBeforeDelete)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +103,7 @@ func (d *Deleter[T]) DeleteOne(ctx context.Context, opts ...*options.DeleteOptio
 		return nil, err
 	}
 
-	err = d.postActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts)), operation.OpTypeAfterDelete)
+	err = d.postActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts), WithModelHook(d.modelHook)), operation.OpTypeAfterDelete)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +112,8 @@ func (d *Deleter[T]) DeleteOne(ctx context.Context, opts ...*options.DeleteOptio
 }
 
 func (d *Deleter[T]) DeleteMany(ctx context.Context, opts ...*options.DeleteOptions) (*mongo.DeleteResult, error) {
-	globalPoContext := operation.NewOpContext(d.collection, operation.WithFilter(d.filter), operation.WithMongoOptions(opts))
-	err := d.preActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts)), operation.OpTypeBeforeDelete)
+	globalPoContext := operation.NewOpContext(d.collection, operation.WithFilter(d.filter), operation.WithMongoOptions(opts), operation.WithModelHook(d.modelHook))
+	err := d.preActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts), WithModelHook(d.modelHook)), operation.OpTypeBeforeDelete)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +123,7 @@ func (d *Deleter[T]) DeleteMany(ctx context.Context, opts ...*options.DeleteOpti
 		return nil, err
 	}
 
-	err = d.postActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts)), operation.OpTypeAfterDelete)
+	err = d.postActionHandler(ctx, globalPoContext, NewOpContext(d.collection, d.filter, WithMongoOptions(opts), WithModelHook(d.modelHook)), operation.OpTypeAfterDelete)
 	if err != nil {
 		return nil, err
 	}

--- a/deleter/opt_op_context_gen.go
+++ b/deleter/opt_op_context_gen.go
@@ -26,3 +26,9 @@ func WithMongoOptions(mongoOptions any) OpContextOption {
 		opContext.MongoOptions = mongoOptions
 	}
 }
+
+func WithModelHook(modelHook any) OpContextOption {
+	return func(opContext *OpContext) {
+		opContext.ModelHook = modelHook
+	}
+}

--- a/deleter/types.go
+++ b/deleter/types.go
@@ -25,6 +25,7 @@ type OpContext struct {
 	Col          *mongo.Collection `opt:"-"`
 	Filter       any               `opt:"-"`
 	MongoOptions any
+	ModelHook    any
 }
 
 type (

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -44,6 +44,7 @@ type Finder[T any] struct {
 	collection  *mongo.Collection
 	filter      any
 	updates     any
+	modelHook   any
 	beforeHooks []beforeHookFn
 	afterHooks  []afterHookFn[T]
 }
@@ -69,6 +70,11 @@ func (f *Finder[T]) Filter(filter any) *Finder[T] {
 
 func (f *Finder[T]) Updates(update any) *Finder[T] {
 	f.updates = update
+	return f
+}
+
+func (f *Finder[T]) ModelHook(modelHook any) *Finder[T] {
+	f.modelHook = modelHook
 	return f
 }
 
@@ -107,8 +113,8 @@ func (f *Finder[T]) postActionHandler(ctx context.Context, globalOpContext *oper
 func (f *Finder[T]) FindOne(ctx context.Context, opts ...*options.FindOneOptions) (*T, error) {
 	t := new(T)
 
-	globalOpContext := operation.NewOpContext(f.collection, operation.WithDoc(t), operation.WithFilter(f.filter), operation.WithMongoOptions(opts))
-	err := f.preActionHandler(ctx, globalOpContext, NewOpContext(f.collection, f.filter, WithMongoOptions(opts)), operation.OpTypeBeforeFind)
+	globalOpContext := operation.NewOpContext(f.collection, operation.WithDoc(t), operation.WithFilter(f.filter), operation.WithMongoOptions(opts), operation.WithModelHook(f.modelHook))
+	err := f.preActionHandler(ctx, globalOpContext, NewOpContext(f.collection, f.filter, WithMongoOptions(opts), WithModelHook(f.modelHook)), operation.OpTypeBeforeFind)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +124,7 @@ func (f *Finder[T]) FindOne(ctx context.Context, opts ...*options.FindOneOptions
 		return nil, err
 	}
 
-	err = f.postActionHandler(ctx, globalOpContext, NewAfterOpContext[T](NewOpContext(f.collection, f.filter, WithMongoOptions(opts)), WithDoc(t)), operation.OpTypeAfterFind)
+	err = f.postActionHandler(ctx, globalOpContext, NewAfterOpContext[T](NewOpContext(f.collection, f.filter, WithMongoOptions(opts), WithModelHook(f.modelHook)), WithDoc(t)), operation.OpTypeAfterFind)
 	if err != nil {
 		return nil, err
 	}
@@ -129,8 +135,8 @@ func (f *Finder[T]) FindOne(ctx context.Context, opts ...*options.FindOneOptions
 func (f *Finder[T]) Find(ctx context.Context, opts ...*options.FindOptions) ([]*T, error) {
 	t := make([]*T, 0)
 
-	opContext := operation.NewOpContext(f.collection, operation.WithFilter(f.filter), operation.WithMongoOptions(opts))
-	err := f.preActionHandler(ctx, opContext, NewOpContext(f.collection, f.filter, WithMongoOptions(opts)), operation.OpTypeBeforeFind)
+	opContext := operation.NewOpContext(f.collection, operation.WithFilter(f.filter), operation.WithMongoOptions(opts), operation.WithModelHook(f.modelHook))
+	err := f.preActionHandler(ctx, opContext, NewOpContext(f.collection, f.filter, WithMongoOptions(opts), WithModelHook(f.modelHook)), operation.OpTypeBeforeFind)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +152,7 @@ func (f *Finder[T]) Find(ctx context.Context, opts ...*options.FindOptions) ([]*
 	}
 
 	opContext.Doc = t
-	err = f.postActionHandler(ctx, opContext, NewAfterOpContext[T](NewOpContext(f.collection, f.filter, WithMongoOptions(opts)), WithDocs(t)), operation.OpTypeAfterFind)
+	err = f.postActionHandler(ctx, opContext, NewAfterOpContext[T](NewOpContext(f.collection, f.filter, WithMongoOptions(opts), WithModelHook(f.modelHook)), WithDocs(t)), operation.OpTypeAfterFind)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +191,8 @@ func (f *Finder[T]) DistinctWithParse(ctx context.Context, fieldName string, res
 func (f *Finder[T]) FindOneAndUpdate(ctx context.Context, opts ...*options.FindOneAndUpdateOptions) (*T, error) {
 	t := new(T)
 
-	globalOpContext := operation.NewOpContext(f.collection, operation.WithDoc(t), operation.WithFilter(f.filter), operation.WithUpdates(f.updates), operation.WithMongoOptions(opts))
-	err := f.preActionHandler(ctx, globalOpContext, NewOpContext(f.collection, f.filter, WithUpdates(f.updates), WithMongoOptions(opts)), operation.OpTypeBeforeFind, operation.OpTypeBeforeUpdate)
+	globalOpContext := operation.NewOpContext(f.collection, operation.WithDoc(t), operation.WithFilter(f.filter), operation.WithUpdates(f.updates), operation.WithMongoOptions(opts), operation.WithModelHook(f.modelHook))
+	err := f.preActionHandler(ctx, globalOpContext, NewOpContext(f.collection, f.filter, WithUpdates(f.updates), WithMongoOptions(opts), WithModelHook(f.modelHook)), operation.OpTypeBeforeFind, operation.OpTypeBeforeUpdate)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +202,7 @@ func (f *Finder[T]) FindOneAndUpdate(ctx context.Context, opts ...*options.FindO
 		return nil, err
 	}
 
-	err = f.postActionHandler(ctx, globalOpContext, NewAfterOpContext[T](NewOpContext(f.collection, f.filter, WithUpdates(f.updates), WithMongoOptions(opts)), WithDoc(t)), operation.OpTypeAfterFind, operation.OpTypeAfterUpdate)
+	err = f.postActionHandler(ctx, globalOpContext, NewAfterOpContext[T](NewOpContext(f.collection, f.filter, WithUpdates(f.updates), WithMongoOptions(opts), WithModelHook(f.modelHook)), WithDoc(t)), operation.OpTypeAfterFind, operation.OpTypeAfterUpdate)
 	if err != nil {
 		return nil, err
 	}

--- a/finder/opt_op_context_gen.go
+++ b/finder/opt_op_context_gen.go
@@ -32,3 +32,9 @@ func WithMongoOptions(mongoOptions any) OpContextOption {
 		opContext.MongoOptions = mongoOptions
 	}
 }
+
+func WithModelHook(modelHook any) OpContextOption {
+	return func(opContext *OpContext) {
+		opContext.ModelHook = modelHook
+	}
+}

--- a/finder/types.go
+++ b/finder/types.go
@@ -29,6 +29,7 @@ type OpContext struct {
 	Filter       any               `opt:"-"`
 	Updates      any
 	MongoOptions any
+	ModelHook    any
 }
 
 //go:generate optioner -type AfterOpContext

--- a/hook/model/model.go
+++ b/hook/model/model.go
@@ -25,11 +25,14 @@ func getPayload(opCtx *operation.OpContext, opType operation.OpType) any {
 	if opCtx == nil {
 		return nil
 	}
+	if opCtx.ModelHook != nil {
+		return opCtx.ModelHook
+	}
 	switch opType {
 	case operation.OpTypeBeforeInsert, operation.OpTypeAfterInsert, operation.OpTypeAfterFind:
 		return opCtx.Doc
 	case operation.OpTypeBeforeUpsert, operation.OpTypeAfterUpsert:
-		return opCtx.Replacement
+		return opCtx.Updates
 	default:
 		return nil
 	}

--- a/operation/operation_type.go
+++ b/operation/operation_type.go
@@ -41,4 +41,5 @@ type OpContext struct {
 	Updates      any
 	Replacement  any
 	MongoOptions any
+	ModelHook    any
 }

--- a/operation/opt_op_context_gen.go
+++ b/operation/opt_op_context_gen.go
@@ -51,3 +51,9 @@ func WithMongoOptions(mongoOptions any) OpContextOption {
 		opContext.MongoOptions = mongoOptions
 	}
 }
+
+func WithModelHook(modelHook any) OpContextOption {
+	return func(opContext *OpContext) {
+		opContext.ModelHook = modelHook
+	}
+}

--- a/updater/opt_cond_context_gen.go
+++ b/updater/opt_cond_context_gen.go
@@ -35,3 +35,9 @@ func WithMongoOptions(mongoOptions any) CondContextOption {
 		condContext.MongoOptions = mongoOptions
 	}
 }
+
+func WithModelHook(modelHook any) CondContextOption {
+	return func(condContext *CondContext) {
+		condContext.ModelHook = modelHook
+	}
+}

--- a/updater/types.go
+++ b/updater/types.go
@@ -29,6 +29,7 @@ type CondContext struct {
 	Updates      any
 	Replacement  any
 	MongoOptions any
+	ModelHook    any
 }
 
 //go:generate optioner -type BeforeOpContext

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -43,6 +43,7 @@ type Updater[T any] struct {
 	filter      any
 	updates     any
 	replacement any
+	modelHook   any
 	beforeHooks []beforeHookFn
 	afterHooks  []afterHookFn
 }
@@ -61,6 +62,11 @@ func (u *Updater[T]) Updates(updates any) *Updater[T] {
 
 func (u *Updater[T]) Replacement(replacement any) *Updater[T] {
 	u.replacement = replacement
+	return u
+}
+
+func (u *Updater[T]) ModelHook(modelHook any) *Updater[T] {
+	u.modelHook = modelHook
 	return u
 }
 
@@ -108,8 +114,8 @@ func (u *Updater[T]) UpdateOne(ctx context.Context, opts ...*options.UpdateOptio
 		u.updates = updates
 	}
 
-	globalOpContext := operation.NewOpContext(u.collection, operation.WithDoc(new(T)), operation.WithFilter(u.filter), operation.WithUpdates(u.updates), operation.WithMongoOptions(opts))
-	err := u.preActionHandler(ctx, globalOpContext, NewBeforeOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts))), operation.OpTypeBeforeUpdate)
+	globalOpContext := operation.NewOpContext(u.collection, operation.WithDoc(new(T)), operation.WithFilter(u.filter), operation.WithUpdates(u.updates), operation.WithMongoOptions(opts), operation.WithModelHook(u.modelHook))
+	err := u.preActionHandler(ctx, globalOpContext, NewBeforeOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts), WithModelHook(u.modelHook))), operation.OpTypeBeforeUpdate)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +125,7 @@ func (u *Updater[T]) UpdateOne(ctx context.Context, opts ...*options.UpdateOptio
 		return nil, err
 	}
 
-	err = u.postActionHandler(ctx, globalOpContext, NewAfterOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts))), operation.OpTypeAfterUpdate)
+	err = u.postActionHandler(ctx, globalOpContext, NewAfterOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts), WithModelHook(u.modelHook))), operation.OpTypeAfterUpdate)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +138,8 @@ func (u *Updater[T]) UpdateMany(ctx context.Context, opts ...*options.UpdateOpti
 		u.updates = updates
 	}
 
-	globalOpContext := operation.NewOpContext(u.collection, operation.WithDoc(new(T)), operation.WithFilter(u.filter), operation.WithUpdates(u.updates), operation.WithMongoOptions(opts))
-	err := u.preActionHandler(ctx, globalOpContext, NewBeforeOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts))), operation.OpTypeBeforeUpdate)
+	globalOpContext := operation.NewOpContext(u.collection, operation.WithDoc(new(T)), operation.WithFilter(u.filter), operation.WithUpdates(u.updates), operation.WithMongoOptions(opts), operation.WithModelHook(u.modelHook))
+	err := u.preActionHandler(ctx, globalOpContext, NewBeforeOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts), WithModelHook(u.modelHook))), operation.OpTypeBeforeUpdate)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +149,7 @@ func (u *Updater[T]) UpdateMany(ctx context.Context, opts ...*options.UpdateOpti
 		return nil, err
 	}
 
-	err = u.postActionHandler(ctx, globalOpContext, NewAfterOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts))), operation.OpTypeAfterUpdate)
+	err = u.postActionHandler(ctx, globalOpContext, NewAfterOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts), WithModelHook(u.modelHook))), operation.OpTypeAfterUpdate)
 	if err != nil {
 		return nil, err
 	}
@@ -162,9 +168,9 @@ func (u *Updater[T]) Upsert(ctx context.Context, opts ...*options.UpdateOptions)
 		u.updates = updates
 	}
 
-	globalOpContext := operation.NewOpContext(u.collection, operation.WithDoc(new(T)), operation.WithFilter(u.filter), operation.WithUpdates(u.updates), operation.WithMongoOptions(opts))
+	globalOpContext := operation.NewOpContext(u.collection, operation.WithDoc(new(T)), operation.WithFilter(u.filter), operation.WithUpdates(u.updates), operation.WithMongoOptions(opts), operation.WithModelHook(u.modelHook))
 
-	err := u.preActionHandler(ctx, globalOpContext, NewBeforeOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts))), operation.OpTypeBeforeUpsert)
+	err := u.preActionHandler(ctx, globalOpContext, NewBeforeOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts), WithModelHook(u.modelHook))), operation.OpTypeBeforeUpsert)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +180,7 @@ func (u *Updater[T]) Upsert(ctx context.Context, opts ...*options.UpdateOptions)
 		return nil, err
 	}
 
-	err = u.postActionHandler(ctx, globalOpContext, NewAfterOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts))), operation.OpTypeAfterUpsert)
+	err = u.postActionHandler(ctx, globalOpContext, NewAfterOpContext(u.collection, NewCondContext(u.filter, WithUpdates(u.updates), WithMongoOptions(opts), WithModelHook(u.modelHook))), operation.OpTypeAfterUpsert)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
feat:
- hook: adjust the implementation of the model hook to handle the default parameters and check if the corresponding interface is implemented based on either the default parameters or the `modelHook` parameter.
- operation: add the ModelHook field to the OpContext struct.
- finder: 
  - add the ModelHook method to set the modelHook value.
  - add the ModelHook field to the OpContext struct.
  - when creating an instance of the operation.OpContext struct and the OpContext struct, pass the ModelHook object.
- creator: 
  - add the ModelHook method to set the modelHook value.
  - add the ModelHook field to the OpContext struct.
  - when creating an instance of the operation.OpContext struct and the OpContext struct, pass the ModelHook object.
- deleter:
  - add the ModelHook method to set the modelHook value.
  - add the ModelHook field to the OpContext struct.
  - when creating an instance of the operation.OpContext struct and the OpContext struct, pass the ModelHook object.
- updater:
  - add the ModelHook method to set the modelHook value.
  - add the ModelHook field to the OpContext struct.
  - when creating an instance of the operation.OpContext struct and the OpContext struct, pass the ModelHook object.