### PR TITLE
Feat: Refactor model hook and add beforeUpdate hook registration for field hook.

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -46,7 +46,7 @@ type PluginConfig struct {
 
 func InitPlugin(config *PluginConfig) {
 	if config.EnableDefaultFieldHook {
-		opTypes := []operation.OpType{operation.OpTypeBeforeInsert, operation.OpTypeBeforeUpsert}
+		opTypes := []operation.OpType{operation.OpTypeBeforeInsert, operation.OpTypeBeforeUpdate, operation.OpTypeBeforeUpsert}
 		for _, opType := range opTypes {
 			typ := opType
 			RegisterPlugin("mongox:default_field", func(ctx context.Context, opCtx *operation.OpContext, opts ...any) error {
@@ -57,8 +57,10 @@ func InitPlugin(config *PluginConfig) {
 	if config.EnableModelHook {
 		opTypes := []operation.OpType{
 			operation.OpTypeBeforeInsert, operation.OpTypeAfterInsert,
+			operation.OpTypeBeforeDelete, operation.OpTypeAfterDelete,
+			operation.OpTypeBeforeUpdate, operation.OpTypeAfterUpdate,
 			operation.OpTypeBeforeUpsert, operation.OpTypeAfterUpsert,
-			operation.OpTypeAfterFind,
+			operation.OpTypeBeforeFind, operation.OpTypeAfterFind,
 		}
 		for _, opType := range opTypes {
 			typ := opType

--- a/hook/model/model.go
+++ b/hook/model/model.go
@@ -28,13 +28,14 @@ func getPayload(opCtx *operation.OpContext, opType operation.OpType) any {
 	if opCtx.ModelHook != nil {
 		return opCtx.ModelHook
 	}
+
 	switch opType {
 	case operation.OpTypeBeforeInsert, operation.OpTypeAfterInsert, operation.OpTypeAfterFind:
 		return opCtx.Doc
-	case operation.OpTypeBeforeUpsert, operation.OpTypeAfterUpsert:
+	case operation.OpTypeBeforeUpdate, operation.OpTypeAfterUpdate, operation.OpTypeBeforeUpsert, operation.OpTypeAfterUpsert:
 		return opCtx.Updates
 	default:
-		return nil
+		return opCtx.ModelHook
 	}
 }
 
@@ -81,6 +82,22 @@ func execute(ctx context.Context, doc any, opType operation.OpType, _ ...any) er
 		if m, ok := doc.(AfterInsert); ok {
 			return m.AfterInsert(ctx)
 		}
+	case operation.OpTypeBeforeDelete:
+		if m, ok := doc.(BeforeDelete); ok {
+			return m.BeforeDelete(ctx)
+		}
+	case operation.OpTypeAfterDelete:
+		if m, ok := doc.(AfterDelete); ok {
+			return m.AfterDelete(ctx)
+		}
+	case operation.OpTypeBeforeUpdate:
+		if m, ok := doc.(BeforeUpdate); ok {
+			return m.BeforeUpdate(ctx)
+		}
+	case operation.OpTypeAfterUpdate:
+		if m, ok := doc.(AfterUpdate); ok {
+			return m.AfterUpdate(ctx)
+		}
 	case operation.OpTypeBeforeUpsert:
 		if m, ok := doc.(BeforeUpsert); ok {
 			return m.BeforeUpsert(ctx)
@@ -88,6 +105,10 @@ func execute(ctx context.Context, doc any, opType operation.OpType, _ ...any) er
 	case operation.OpTypeAfterUpsert:
 		if m, ok := doc.(AfterUpsert); ok {
 			return m.AfterUpsert(ctx)
+		}
+	case operation.OpTypeBeforeFind:
+		if m, ok := doc.(BeforeFind); ok {
+			return m.BeforeFind(ctx)
 		}
 	case operation.OpTypeAfterFind:
 		if m, ok := doc.(AfterFind); ok {


### PR DESCRIPTION
feat:
- hook: refactor the model hook to add support for the `beforeDelete`, `afterDelete`, `beforeUpdate`, `afterUpdate`, and `beforeFind` hooks in MongoDB operations.
- plugin: add the registration of the `beforeUpdate` hook when the field hook is enabled.