### PR TITLE
fix: Resolve the issue where FindOneAndUpdate does not update the timestamp

### DIFF
--- a/finder/finder.go
+++ b/finder/finder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/chenmingyong0423/go-mongox/v2/bsonx"
 	"github.com/chenmingyong0423/go-mongox/v2/field"
 
 	"github.com/chenmingyong0423/go-mongox/v2/callback"
@@ -34,6 +35,8 @@ type IFinder[T any] interface {
 	FindOne(ctx context.Context, opts ...options.Lister[options.FindOneOptions]) (*T, error)
 	Find(ctx context.Context, opts ...options.Lister[options.FindOptions]) ([]*T, error)
 	Count(ctx context.Context, opts ...options.Lister[options.CountOptions]) (int64, error)
+	FindOneAndUpdate(ctx context.Context, opts ...options.Lister[options.
+		FindOneAndUpdateOptions]) (*T, error)
 }
 
 func NewFinder[T any](collection *mongo.Collection, callbacks *callback.Callback, fields []*field.Filed) *Finder[T] {
@@ -235,6 +238,12 @@ func (f *Finder[T]) DistinctWithParse(ctx context.Context, fieldName string, res
 func (f *Finder[T]) FindOneAndUpdate(ctx context.Context, opts ...options.Lister[options.FindOneAndUpdateOptions]) (*T, error) {
 	currentTime := time.Now()
 	t := new(T)
+
+	updates := bsonx.ToBsonM(f.updates)
+	if len(updates) != 0 {
+		f.updates = updates
+	}
+
 	globalOpContext := operation.NewOpContext(f.collection, operation.WithFilter(f.filter), operation.WithUpdates(f.updates), operation.WithMongoOptions(opts), operation.WithModelHook(f.modelHook), operation.WithStartTime(currentTime), operation.WithFields(f.fields))
 	opContext := NewOpContext(f.collection, f.filter, WithUpdates[T](f.updates), WithMongoOptions[T](opts), WithModelHook[T](f.modelHook), WithStartTime[T](currentTime), WithFields[T](f.fields))
 

--- a/finder/finder_e2e_test.go
+++ b/finder/finder_e2e_test.go
@@ -1351,7 +1351,8 @@ func TestFinder_e2e_FindOneAndUpdate(t *testing.T) {
 						if opCtx.Filter.(bson.D)[0].Key != "name" || opCtx.Filter.(bson.D)[0].Value.(bson.D)[0].Value != "Mingyong Chen" {
 							return errors.New("filter error")
 						}
-						if opCtx.Updates.(bson.D)[0].Value.(bson.D)[0].Key != "age" || opCtx.Updates.(bson.D)[0].Value.(bson.D)[0].Value != 24 {
+
+						if opCtx.Updates.(bson.M)["$set"].(bson.M)["age"].(int32) != 24 {
 							return errors.New("updates error")
 						}
 						return nil
@@ -1438,7 +1439,7 @@ func TestFinder_e2e_FindOneAndUpdate(t *testing.T) {
 					if opCtx.Filter.(bson.D)[0].Key != "name" || opCtx.Filter.(bson.D)[0].Value.(bson.D)[0].Value != "Mingyong Chen" {
 						return errors.New("filter error")
 					}
-					if opCtx.Updates.(bson.D)[0].Value.(bson.D)[0].Key != "age" || opCtx.Updates.(bson.D)[0].Value.(bson.D)[0].Value != 24 {
+					if opCtx.Updates.(bson.M)["$set"].(bson.M)["age"].(int32) != 24 {
 						return errors.New("updates error")
 					}
 					return nil
@@ -1473,6 +1474,13 @@ func TestFinder_e2e_FindOneAndUpdate(t *testing.T) {
 			require.Equal(t, tc.wantErr, err)
 			if err == nil {
 				tc.want.ID = user.ID
+				zeroTim := time.Time{}
+				if user != nil && user.UpdatedAt != zeroTim {
+					if user.UpdatedAt == tc.want.UpdatedAt {
+						t.FailNow()
+					}
+					tc.want.UpdatedAt = user.UpdatedAt
+				}
 				require.Equal(t, tc.want, user)
 			}
 			for _, hook := range tc.globalHook {

--- a/finder/finder_e2e_test.go
+++ b/finder/finder_e2e_test.go
@@ -1262,6 +1262,12 @@ func TestFinder_e2e_FindOneAndUpdate(t *testing.T) {
 				require.NotNil(t, insertOneResult.InsertedID)
 			},
 			after: func(ctx context.Context, t *testing.T) {
+				result, err := finder.Filter(query.Eq("name", "Mingyong Chen")).FindOne(ctx)
+				require.NoError(t, err)
+				zeroTim := time.Time{}
+				if result.UpdatedAt == zeroTim {
+					require.Error(t, errors.New("updatedAt is not updated"))
+				}
 				deleteOneResult, err := collection.DeleteOne(ctx, query.Eq("name", "Mingyong Chen"))
 				require.NoError(t, err)
 				require.Equal(t, int64(1), deleteOneResult.DeletedCount)
@@ -1366,6 +1372,10 @@ func TestFinder_e2e_FindOneAndUpdate(t *testing.T) {
 						if user.Name != "Mingyong Chen" || user.Age != 24 {
 							return errors.New("result error")
 						}
+						zeroTim := time.Time{}
+						if user.UpdatedAt == zeroTim {
+							return errors.New("updatedAt is not updated")
+						}
 						return nil
 					},
 				},
@@ -1450,6 +1460,10 @@ func TestFinder_e2e_FindOneAndUpdate(t *testing.T) {
 					user := opCtx.Doc
 					if user.Name != "Mingyong Chen" || user.Age != 24 {
 						return errors.New("after error")
+					}
+					zeroTim := time.Time{}
+					if user.UpdatedAt == zeroTim {
+						return errors.New("updatedAt is not updated")
 					}
 					return nil
 				},

--- a/finder/finder_test.go
+++ b/finder/finder_test.go
@@ -216,3 +216,56 @@ func TestFinder_Count(t *testing.T) {
 		})
 	}
 }
+
+func TestFindOneAndUpdate(t *testing.T) {
+	type TestUser struct {
+		ID           bson.ObjectID `bson:"_id,omitempty"`
+		Name         string        `bson:"name"`
+		Age          int64
+		UnknownField string    `bson:"-"`
+		CreatedAt    time.Time `bson:"created_at"`
+		UpdatedAt    time.Time `bson:"updated_at"`
+	}
+	testCases := []struct {
+		name string
+		mock func(ctx context.Context, ctl *gomock.Controller) IFinder[TestUser]
+
+		ctx     context.Context
+		want    *TestUser
+		wantErr error
+	}{
+		{
+			name: "error",
+			mock: func(ctx context.Context, ctl *gomock.Controller) IFinder[TestUser] {
+				mockCollection := mocks.NewMockIFinder[TestUser](ctl)
+				mockCollection.EXPECT().FindOneAndUpdate(ctx).Return(nil, mongo.ErrNoDocuments).Times(1)
+				return mockCollection
+			},
+
+			ctx:     context.Background(),
+			want:    nil,
+			wantErr: mongo.ErrNoDocuments,
+		},
+		{
+			name: "match the first one and update",
+			mock: func(ctx context.Context, ctl *gomock.Controller) IFinder[TestUser] {
+				mockCollection := mocks.NewMockIFinder[TestUser](ctl)
+				mockCollection.EXPECT().FindOneAndUpdate(ctx).Return(&TestUser{Name: "hejiangda", Age: 18}, nil).Times(1)
+				return mockCollection
+			},
+			ctx:  context.Background(),
+			want: &TestUser{Name: "hejiangda", Age: 18},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			defer ctl.Finish()
+			finder := tc.mock(tc.ctx, ctl)
+
+			user, err := finder.FindOneAndUpdate(tc.ctx)
+			assert.Equal(t, tc.wantErr, err)
+			assert.Equal(t, tc.want, user)
+		})
+	}
+}

--- a/mock/finder.mock.go
+++ b/mock/finder.mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=finder.go -destination=../mock/finder.mock.go -package=mocks
 //
+
 // Package mocks is a generated GoMock package.
 package mocks
 
@@ -20,6 +21,7 @@ import (
 type MockIFinder[T any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockIFinderMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockIFinderMockRecorder is the mock recorder for MockIFinder.
@@ -97,4 +99,24 @@ func (mr *MockIFinderMockRecorder[T]) FindOne(ctx any, opts ...any) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOne", reflect.TypeOf((*MockIFinder[T])(nil).FindOne), varargs...)
+}
+
+// FindOneAndUpdate mocks base method.
+func (m *MockIFinder[T]) FindOneAndUpdate(ctx context.Context, opts ...options.Lister[options.FindOneAndUpdateOptions]) (*T, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FindOneAndUpdate", varargs...)
+	ret0, _ := ret[0].(*T)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindOneAndUpdate indicates an expected call of FindOneAndUpdate.
+func (mr *MockIFinderMockRecorder[T]) FindOneAndUpdate(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOneAndUpdate", reflect.TypeOf((*MockIFinder[T])(nil).FindOneAndUpdate), varargs...)
 }


### PR DESCRIPTION
In finder/finder.go I convert the f.updates from bson.D to bson.M to make it avaiable for beforeUpdate function in internal/hook/field/strategy.go 