### PR TITLE
fix: correct OpType usage in Aggregator component (#106)

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -78,7 +78,7 @@ func (a *Aggregator[T]) Aggregate(ctx context.Context, opts ...options.Lister[op
 	globalOpContext := operation.NewOpContext(a.collection, operation.WithPipeline(a.pipeline), operation.WithMongoOptions(opts), operation.WithModelHook(a.modelHook), operation.WithStartTime(currentTime), operation.WithFields(a.fields))
 	opContext := NewOpContext(a.collection, a.pipeline, WithMongoOptions(opts), WithModelHook(a.modelHook), WithStartTime(currentTime), WithFields(a.fields))
 
-	err := a.preActionHandler(ctx, globalOpContext, opContext, operation.OpTypeBeforeInsert)
+	err := a.preActionHandler(ctx, globalOpContext, opContext, operation.OpTypeBeforeAggregate)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (a *Aggregator[T]) Aggregate(ctx context.Context, opts ...options.Lister[op
 
 	globalOpContext.Result = cursor
 	opContext.Result = cursor
-	err = a.postActionHandler(ctx, globalOpContext, opContext, operation.OpTypeAfterInsert)
+	err = a.postActionHandler(ctx, globalOpContext, opContext, operation.OpTypeAfterAggregate)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (a *Aggregator[T]) AggregateWithParse(ctx context.Context, result any, opts
 	globalOpContext := operation.NewOpContext(a.collection, operation.WithPipeline(a.pipeline), operation.WithMongoOptions(opts), operation.WithModelHook(a.modelHook), operation.WithStartTime(currentTime), operation.WithFields(a.fields))
 	opContext := NewOpContext(a.collection, a.pipeline, WithMongoOptions(opts), WithModelHook(a.modelHook), WithStartTime(currentTime), WithFields(a.fields))
 
-	err := a.preActionHandler(ctx, globalOpContext, opContext, operation.OpTypeBeforeInsert)
+	err := a.preActionHandler(ctx, globalOpContext, opContext, operation.OpTypeBeforeAggregate)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (a *Aggregator[T]) AggregateWithParse(ctx context.Context, result any, opts
 
 	globalOpContext.Result = cursor
 	opContext.Result = cursor
-	err = a.postActionHandler(ctx, globalOpContext, opContext, operation.OpTypeAfterInsert)
+	err = a.postActionHandler(ctx, globalOpContext, opContext, operation.OpTypeAfterAggregate)
 	if err != nil {
 		return err
 	}

--- a/operation/operation_type.go
+++ b/operation/operation_type.go
@@ -30,18 +30,20 @@ import (
 type OpType string
 
 const (
-	OpTypeBeforeInsert OpType = "beforeInsert"
-	OpTypeAfterInsert  OpType = "afterInsert"
-	OpTypeBeforeUpdate OpType = "beforeUpdate"
-	OpTypeAfterUpdate  OpType = "afterUpdate"
-	OpTypeBeforeDelete OpType = "beforeDelete"
-	OpTypeAfterDelete  OpType = "afterDelete"
-	OpTypeBeforeUpsert OpType = "beforeUpsert"
-	OpTypeAfterUpsert  OpType = "afterUpsert"
-	OpTypeBeforeFind   OpType = "beforeFind"
-	OpTypeAfterFind    OpType = "afterFind"
-	OpTypeBeforeAny    OpType = "before*"
-	OpTypeAfterAny     OpType = "after*"
+	OpTypeBeforeInsert    OpType = "beforeInsert"
+	OpTypeAfterInsert     OpType = "afterInsert"
+	OpTypeBeforeUpdate    OpType = "beforeUpdate"
+	OpTypeAfterUpdate     OpType = "afterUpdate"
+	OpTypeBeforeDelete    OpType = "beforeDelete"
+	OpTypeAfterDelete     OpType = "afterDelete"
+	OpTypeBeforeUpsert    OpType = "beforeUpsert"
+	OpTypeAfterUpsert     OpType = "afterUpsert"
+	OpTypeBeforeFind      OpType = "beforeFind"
+	OpTypeAfterFind       OpType = "afterFind"
+	OpTypeBeforeAggregate OpType = "beforeAggregate"
+	OpTypeAfterAggregate  OpType = "afterAggregate"
+	OpTypeBeforeAny       OpType = "before*"
+	OpTypeAfterAny        OpType = "after*"
 )
 
 //go:generate optioner -type OpContext -output operation_type.go -mode append


### PR DESCRIPTION
This PR resolves a bug that prevented aggregation hooks from functioning correctly. The `Aggregator` component was incorrectly firing `OpType...Insert` hooks instead of dedicated aggregation hooks.

**Changes:**
- **`operation`**: Introduced `OpTypeBeforeAggregate` and `OpTypeAfterAggregate`.
- **`callback`**: Integrated the new aggregation `OpType`s into the callback execution, registration, and removal logic, including wildcard (`*Any`) support.
- **`aggregator`**: Updated `preActionHandler` and `postActionHandler` to use the correct aggregation `OpType`s.
- **`tests`**: Added a unit test to isolate the callback logic and a new E2E test to confirm the fix in a realistic scenario.

Thank you for the opportunity to contribute and for reviewing the changes.

Closes #106 